### PR TITLE
Fix security vulnerabilities #11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
 		<plugin>
 			<groupId>org.jacoco</groupId>
 			<artifactId>jacoco-maven-plugin</artifactId>
+			<version>${jacoco-maven-plugin.version}</version>
 			<executions>
 				<execution>
 					<id>jacoco-initialize</id>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.4.RELEASE</version>
+		<version>2.2.0.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<properties>
@@ -23,6 +23,9 @@
         <java.version>8</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
+		<springfox-swagger.version>2.9.2</springfox-swagger.version>
+		<jaxb.version>2.3.1</jaxb.version>
+		<jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
 	</properties>
 
 	<dependencies>
@@ -72,20 +75,26 @@
 		<dependency>
 			<groupId>io.springfox</groupId>
 			<artifactId>springfox-swagger-ui</artifactId>
-			<version>2.9.2</version>
+			<version>${springfox-swagger.version}</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.springfox</groupId>
 			<artifactId>springfox-swagger2</artifactId>
-			<version>2.9.2</version>
+			<version>${springfox-swagger.version}</version>
 			<scope>compile</scope>
 		</dependency>
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
-            <version>2.3.0</version>
+            <version>${jaxb.version}</version>
         </dependency>
+		<dependency>
+			<groupId>org.jacoco</groupId>
+			<artifactId>jacoco-maven-plugin</artifactId>
+			<version>${jacoco-maven-plugin.version}</version>
+			<type>maven-plugin</type>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Resolves #11.

Updated Snyk report:

```
Tested 119 dependencies for known issues, found 10 issues, 10 vulnerable paths.


Issues with no direct upgrade or patch:
  ✗ Deserialization of Untrusted Data [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-32236] in com.google.guava:guava@20.0
    introduced by io.springfox:springfox-swagger2@2.9.2 > com.google.guava:guava@20.0
  This issue was fixed in versions: 24.1.1-android, 24.1.1-jre
  ✗ Deserialization of Untrusted Data [High Severity][https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078] in commons-collections:commons-collections@3.2
    introduced by org.jacoco:jacoco-maven-plugin@0.8.5 > org.apache.maven.reporting:maven-reporting-impl@2.1 > org.apache.maven.doxia:doxia-site-renderer@1.1.2 > commons-collections:commons-collections@3.2
  This issue was fixed in versions: 3.2.2
  ✗ Improper Certificate Validation [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMMONSHTTPCLIENT-30083] in commons-httpclient:commons-httpclient@3.1
    introduced by org.jacoco:jacoco-maven-plugin@0.8.5 > org.apache.maven.reporting:maven-reporting-impl@2.1 > org.apache.maven.doxia:doxia-core@1.1.2 > commons-httpclient:commons-httpclient@3.1
  No upgrade or patch available
  ✗ Man-in-the-Middle (MitM) [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMMONSHTTPCLIENT-31660] in commons-httpclient:commons-httpclient@3.1
    introduced by org.jacoco:jacoco-maven-plugin@0.8.5 > org.apache.maven.reporting:maven-reporting-impl@2.1 > org.apache.maven.doxia:doxia-core@1.1.2 > commons-httpclient:commons-httpclient@3.1
  No upgrade or patch available
  ✗ Directory Traversal [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-ORGCODEHAUSPLEXUS-31521] in org.codehaus.plexus:plexus-utils@3.0.22
    introduced by org.jacoco:jacoco-maven-plugin@0.8.5 > org.codehaus.plexus:plexus-utils@3.0.22
  This issue was fixed in versions: 3.0.24
  ✗ XML Injection [Low Severity][https://snyk.io/vuln/SNYK-JAVA-ORGCODEHAUSPLEXUS-461102] in org.codehaus.plexus:plexus-utils@3.0.22
    introduced by org.jacoco:jacoco-maven-plugin@0.8.5 > org.codehaus.plexus:plexus-utils@3.0.22
  This issue was fixed in versions: 3.0.24
  ✗ Denial of Service (DoS) [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-XERCES-30183] in xerces:xercesImpl@2.8.1
    introduced by org.jacoco:jacoco-maven-plugin@0.8.5 > org.apache.maven.reporting:maven-reporting-impl@2.1 > org.apache.maven.doxia:doxia-core@1.1.2 > xerces:xercesImpl@2.8.1
  This issue was fixed in versions: 2.12.0
  ✗ Denial of Service (DoS) [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-XERCES-31497] in xerces:xercesImpl@2.8.1
    introduced by org.jacoco:jacoco-maven-plugin@0.8.5 > org.apache.maven.reporting:maven-reporting-impl@2.1 > org.apache.maven.doxia:doxia-core@1.1.2 > xerces:xercesImpl@2.8.1
  This issue was fixed in versions: 2.11.0
  ✗ Denial of Service (DoS) [High Severity][https://snyk.io/vuln/SNYK-JAVA-XERCES-31585] in xerces:xercesImpl@2.8.1
    introduced by org.jacoco:jacoco-maven-plugin@0.8.5 > org.apache.maven.reporting:maven-reporting-impl@2.1 > org.apache.maven.doxia:doxia-core@1.1.2 > xerces:xercesImpl@2.8.1
  This issue was fixed in versions: 2.12.0
  ✗ Denial of Service (DoS) [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-XERCES-32014] in xerces:xercesImpl@2.8.1
    introduced by org.jacoco:jacoco-maven-plugin@0.8.5 > org.apache.maven.reporting:maven-reporting-impl@2.1 > org.apache.maven.doxia:doxia-core@1.1.2 > xerces:xercesImpl@2.8.1
  This issue was fixed in versions: 2.10.0
```

There are still some vulnerabilities from `io.springfox:springfox-swagger2@2.9.2` and `org.jacoco:jacoco-maven-plugin@0.8.5`. These dependencies are already in their latest versions and have not yet patched these vulnerabilities.