### PR TITLE
Resolve #11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,15 +14,18 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.4.RELEASE</version>
+		<version>2.2.0.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>8</java.version>
+		<java.version>8</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
+		<springfox-swagger.version>2.9.2</springfox-swagger.version>
+		<jaxb.version>2.3.1</jaxb.version>
+		<jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
 	</properties>
 
 	<dependencies>
@@ -72,20 +75,26 @@
 		<dependency>
 			<groupId>io.springfox</groupId>
 			<artifactId>springfox-swagger-ui</artifactId>
-			<version>2.9.2</version>
+			<version>${springfox-swagger.version}</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.springfox</groupId>
 			<artifactId>springfox-swagger2</artifactId>
-			<version>2.9.2</version>
+			<version>${springfox-swagger.version}</version>
 			<scope>compile</scope>
 		</dependency>
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.0</version>
-        </dependency>
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>${jaxb.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jacoco</groupId>
+			<artifactId>jacoco-maven-plugin</artifactId>
+			<version>${jacoco-maven-plugin.version}</version>
+			<type>maven-plugin</type>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -95,32 +104,33 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
-		<plugin>
-			<groupId>org.jacoco</groupId>
-			<artifactId>jacoco-maven-plugin</artifactId>
-			<executions>
-				<execution>
-					<id>jacoco-initialize</id>
-					<goals>
-						<goal>prepare-agent</goal>
-					</goals>
-				</execution>
-				<execution>
-					<id>jacoco-site</id>
-					<phase>package</phase>
-					<goals>
-						<goal>report</goal>
-					</goals>
-				</execution>
-				<execution>
-					<id>jacoco-test-report</id>
-					<phase>test</phase>
-					<goals>
-						<goal>report</goal>
-					</goals>
-				</execution>
-			</executions>
-		</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>${jacoco-maven-plugin.version}</version>
+				<executions>
+					<execution>
+						<id>jacoco-initialize</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>jacoco-site</id>
+						<phase>package</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>jacoco-test-report</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 
 		</plugins>
 

--- a/src/test/java/io/vpv/math/problemgenerateor/ProblemGenerateorApplicationTests.java
+++ b/src/test/java/io/vpv/math/problemgenerateor/ProblemGenerateorApplicationTests.java
@@ -4,10 +4,12 @@ import io.vpv.math.problemgenerateor.model.User;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
+@ActiveProfiles("test")
 public class ProblemGenerateorApplicationTests {
 
 	@Test

--- a/src/test/java/io/vpv/math/problemgenerateor/controller/api/MainTest.java
+++ b/src/test/java/io/vpv/math/problemgenerateor/controller/api/MainTest.java
@@ -11,6 +11,7 @@ public class MainTest {
     @Test
     public void main() {
         System.setProperty("server.port", "8181");
+        System.setProperty("spring.profiles.active", "test");
         ProblemGenerateorApplication.main(new String[]{});
     }
 }

--- a/src/test/java/io/vpv/math/problemgenerateor/controller/api/ProblemGeneratorAPITest.java
+++ b/src/test/java/io/vpv/math/problemgenerateor/controller/api/ProblemGeneratorAPITest.java
@@ -33,14 +33,14 @@ public class ProblemGeneratorAPITest extends ProblemGenerateorApplicationTests {
     public void getAllApiEndpoints() throws Exception {
         mockMvc.perform(get("/api").session(mockHttpSession))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(jsonPath("$[0]").isNotEmpty());
     }
     @Test
     public void getAddProblems() throws Exception {
         mockMvc.perform(get("/api/add").session(mockHttpSession))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(jsonPath("$[0].firstNumber").isNotEmpty());
     }
 
@@ -48,7 +48,7 @@ public class ProblemGeneratorAPITest extends ProblemGenerateorApplicationTests {
     public void getSubProblems() throws Exception {
         mockMvc.perform(get("/api/sub").session(mockHttpSession))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(jsonPath("$[0].firstNumber").isNotEmpty());
     }
 
@@ -56,7 +56,7 @@ public class ProblemGeneratorAPITest extends ProblemGenerateorApplicationTests {
     public void getAddSubProblems() throws Exception {
         mockMvc.perform(get("/api/addsub").session(mockHttpSession))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(jsonPath("$[0].firstNumber").isNotEmpty());
     }
 
@@ -65,7 +65,7 @@ public class ProblemGeneratorAPITest extends ProblemGenerateorApplicationTests {
     public void getMulProblems() throws Exception {
         mockMvc.perform(get("/api/mul").session(mockHttpSession))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(jsonPath("$[0].firstNumber").isNotEmpty());
     }
 
@@ -73,7 +73,7 @@ public class ProblemGeneratorAPITest extends ProblemGenerateorApplicationTests {
     public void getDivProblems() throws Exception {
         mockMvc.perform(get("/api/div").session(mockHttpSession))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(jsonPath("$[0].firstNumber").isNotEmpty());
     }
 

--- a/src/test/java/io/vpv/math/problemgenerateor/controller/api/UserAPITest.java
+++ b/src/test/java/io/vpv/math/problemgenerateor/controller/api/UserAPITest.java
@@ -34,7 +34,7 @@ public class UserAPITest extends ProblemGenerateorApplicationTests {
     public void getUserFromSession() throws Exception {
         mockMvc.perform(get("/api/user").session(mockHttpSession))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(jsonPath("$.firstName").isNotEmpty())
                 .andExpect(jsonPath("$.lastName").isNotEmpty())
                 .andExpect(jsonPath("$.email").isNotEmpty());
@@ -45,6 +45,6 @@ public class UserAPITest extends ProblemGenerateorApplicationTests {
     public void getUserFromEmptySession() throws Exception {
         mockMvc.perform(get("/api/user"))
                 .andExpect(status().is4xxClientError())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE));
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE));
     }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,12 @@
+loader:
+  verbose: true
+logging:
+  level:
+    org:
+      springframework:
+
+app:
+  askLogin: "https://truelogin.vpv.io/whoisthis?callback="
+  localEndpoint: "http://localhost:8080/"
+  aeskey: s3cr3tk3s3cr3tk3
+  callback: LOCAL_TESTING


### PR DESCRIPTION
Issues with no direct upgrade or patch:
  ✗ Deserialization of Untrusted Data [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-32236] in com.google.guava:guava@20.0
    introduced by io.springfox:springfox-swagger2@2.9.2 > com.google.guava:guava@20.0
  This issue was fixed in versions: 24.1.1-android, 24.1.1-jre
  ✗ Deserialization of Untrusted Data [High Severity][https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078] in commons-collections:commons-collections@3.2
    introduced by org.jacoco:jacoco-maven-plugin@0.8.5 > org.apache.maven.reporting:maven-reporting-impl@2.1 > org.apache.maven.doxia:doxia-site-renderer@1.1.2 > commons-collections:commons-collections@3.2
  This issue was fixed in versions: 3.2.2
  ✗ Improper Certificate Validation [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMMONSHTTPCLIENT-30083] in commons-httpclient:commons-httpclient@3.1
    introduced by org.jacoco:jacoco-maven-plugin@0.8.5 > org.apache.maven.reporting:maven-reporting-impl@2.1 > org.apache.maven.doxia:doxia-core@1.1.2 > commons-httpclient:commons-httpclient@3.1
  No upgrade or patch available
  ✗ Man-in-the-Middle (MitM) [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMMONSHTTPCLIENT-31660] in commons-httpclient:commons-httpclient@3.1
    introduced by org.jacoco:jacoco-maven-plugin@0.8.5 > org.apache.maven.reporting:maven-reporting-impl@2.1 > org.apache.maven.doxia:doxia-core@1.1.2 > commons-httpclient:commons-httpclient@3.1
  No upgrade or patch available
  ✗ Directory Traversal [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-ORGCODEHAUSPLEXUS-31521] in org.codehaus.plexus:plexus-utils@3.0.22
    introduced by org.jacoco:jacoco-maven-plugin@0.8.5 > org.codehaus.plexus:plexus-utils@3.0.22
  This issue was fixed in versions: 3.0.24
  ✗ XML Injection [Low Severity][https://snyk.io/vuln/SNYK-JAVA-ORGCODEHAUSPLEXUS-461102] in org.codehaus.plexus:plexus-utils@3.0.22
    introduced by org.jacoco:jacoco-maven-plugin@0.8.5 > org.codehaus.plexus:plexus-utils@3.0.22
  This issue was fixed in versions: 3.0.24
  ✗ Denial of Service (DoS) [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-XERCES-30183] in xerces:xercesImpl@2.8.1
    introduced by org.jacoco:jacoco-maven-plugin@0.8.5 > org.apache.maven.reporting:maven-reporting-impl@2.1 > org.apache.maven.doxia:doxia-core@1.1.2 > xerces:xercesImpl@2.8.1
  This issue was fixed in versions: 2.12.0
  ✗ Denial of Service (DoS) [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-XERCES-31497] in xerces:xercesImpl@2.8.1
    introduced by org.jacoco:jacoco-maven-plugin@0.8.5 > org.apache.maven.reporting:maven-reporting-impl@2.1 > org.apache.maven.doxia:doxia-core@1.1.2 > xerces:xercesImpl@2.8.1
  This issue was fixed in versions: 2.11.0
  ✗ Denial of Service (DoS) [High Severity][https://snyk.io/vuln/SNYK-JAVA-XERCES-31585] in xerces:xercesImpl@2.8.1
    introduced by org.jacoco:jacoco-maven-plugin@0.8.5 > org.apache.maven.reporting:maven-reporting-impl@2.1 > org.apache.maven.doxia:doxia-core@1.1.2 > xerces:xercesImpl@2.8.1
  This issue was fixed in versions: 2.12.0
  ✗ Denial of Service (DoS) [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-XERCES-32014] in xerces:xercesImpl@2.8.1
    introduced by org.jacoco:jacoco-maven-plugin@0.8.5 > org.apache.maven.reporting:maven-reporting-impl@2.1 > org.apache.maven.doxia:doxia-core@1.1.2 > xerces:xercesImpl@2.8.1
  This issue was fixed in versions: 2.10.0